### PR TITLE
feat: mock external APIs and add scheduler time multiplier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ OPENAI_API_KEY="your-openai-key"
 OVERLAY_WS_TOKEN="change-me"
 VITE_OVERLAY_TOKEN="change-me"
 OVERLAY_RATE_LIMIT="60" # messages per minute per client
+SCHEDULER_TIME_MULTIPLIER="1" # accelerate reminders during tests (CLI/config override)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ npm test               # Run end-to-end guardians
 npm run overlay:server # Launch overlay WebSocket server (requires OVERLAY_WS_TOKEN)
 ```
 
+### Scheduler Time Multiplier
+
+`SCHEDULER_TIME_MULTIPLIER` lets you warp time for reminders. Setting it to `600` turns a 10‑minute delay into roughly one second—handy for tests and demos where the cosmos can't wait. You can also override this value on the fly:
+
+```bash
+node packages/voice-notes/index.js --time-multiplier=600
+# or point to a JSON config file containing {"timeMultiplier":600}
+node packages/voice-notes/index.js --config=voice.json
+```
+
 ### CI Guardians
 Continuous integration watches from the heavens. A GitHub Action runs `npm test` on each push, ensuring every ritual remains pure.
 

--- a/packages/voice-notes/config.js
+++ b/packages/voice-notes/config.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+// Parse CLI arguments of the form --key=value
+function parseArgs(argv) {
+  return argv.reduce((acc, arg) => {
+    if (arg.startsWith('--')) {
+      const [key, value] = arg.slice(2).split('=');
+      acc[key] = value ?? true;
+    }
+    return acc;
+  }, {});
+}
+
+const args = parseArgs(process.argv.slice(2));
+
+// Optional JSON config file via --config=path/to/file.json
+let fileConfig = {};
+if (args.config) {
+  try {
+    const filePath = path.resolve(args.config);
+    fileConfig = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch (err) {
+    console.warn(`Failed to read config file ${args.config}: ${err.message}`);
+  }
+}
+
+// Priority: CLI > config file > env var > default
+const config = {
+  timeMultiplier:
+    Number(
+      args['time-multiplier'] ??
+        fileConfig.timeMultiplier ??
+        process.env.SCHEDULER_TIME_MULTIPLIER
+    ) || 1
+};
+
+module.exports = config;

--- a/packages/voice-notes/index.js
+++ b/packages/voice-notes/index.js
@@ -11,6 +11,7 @@ const schedule = require('node-schedule');
 const { createEvent } = require('ics');
 const fs = require('fs');
 const path = require('path');
+const config = require('./config');
 
 // Directory where generated ICS files live for calendar import.
 const EVENTS_DIR = path.join(__dirname, 'events');
@@ -18,30 +19,45 @@ if (!fs.existsSync(EVENTS_DIR)) fs.mkdirSync(EVENTS_DIR, { recursive: true });
 
 /**
  * Parse reminder text, schedule callback, and persist ICS event.
+ * Allows a time multiplier so long-term reminders can be simulated quickly
+ * during tests or demos. Multiplier can be set via CLI (--time-multiplier),
+ * config file, or SCHEDULER_TIME_MULTIPLIER env var.
+ *
  * @param {string} text natural language command e.g. "remind me tomorrow at 5pm to hydrate".
+ * @param {{createEvent?: Function, timeMultiplier?: number}} [opts]
  * @returns {{id: string, title: string, date: Date}|null}
  */
-function scheduleReminder(text) {
+function scheduleReminder(text, opts = {}) {
   const parsed = chrono.parse(text);
   if (!parsed.length) return null;
-  const date = parsed[0].start.date();
+
+  const originalDate = parsed[0].start.date();
   const title = text.replace(/remind me/i, '').trim() || 'Reminder';
   const id = `reminder-${Date.now()}`;
 
-  // Schedule a simple console log when reminder triggers.
-  schedule.scheduleJob(id, date, () => {
-    console.log(`🔔 Reminder triggered: ${title} @ ${date.toISOString()}`);
+  // Collapse long delays so tests don't wait eons.
+  const multiplier = Number(opts.timeMultiplier ?? config.timeMultiplier) || 1;
+  const now = Date.now();
+  const scheduledDate =
+    multiplier > 1
+      ? new Date(now + (originalDate.getTime() - now) / multiplier)
+      : originalDate;
+
+  // Schedule a simple console log when the reminder triggers.
+  schedule.scheduleJob(id, scheduledDate, () => {
+    console.log(`🔔 Reminder triggered: ${title} @ ${scheduledDate.toISOString()}`);
   });
 
   // Export ICS event for calendar integration.
-  const { error, value } = createEvent({
+  const create = opts.createEvent || createEvent;
+  const { error, value } = create({
     title,
     start: [
-      date.getFullYear(),
-      date.getMonth() + 1,
-      date.getDate(),
-      date.getHours(),
-      date.getMinutes()
+      scheduledDate.getFullYear(),
+      scheduledDate.getMonth() + 1,
+      scheduledDate.getDate(),
+      scheduledDate.getHours(),
+      scheduledDate.getMinutes()
     ],
     duration: { minutes: 5 }
   });
@@ -49,7 +65,7 @@ function scheduleReminder(text) {
     fs.writeFileSync(path.join(EVENTS_DIR, `${id}.ics`), value);
   }
 
-  return { id, title, date };
+  return { id, title, date: scheduledDate };
 }
 
 /**
@@ -57,15 +73,16 @@ function scheduleReminder(text) {
  * @param {Buffer} audioBuffer raw PCM or WAV data.
  * @returns {Promise<{id: string, title: string, date: Date}|null>}
  */
-async function processWhisper(audioBuffer) {
+async function processWhisper(audioBuffer, deps = {}) {
   const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
+  if (!apiKey && !deps.openAIClient) {
     console.warn('OPENAI_API_KEY not set; skipping transcription.');
     return null;
   }
 
   try {
-    const openai = new OpenAI({ apiKey });
+    const openai = deps.openAIClient || new OpenAI({ apiKey });
+    const scheduleFn = deps.scheduleReminder || scheduleReminder;
 
     // Wrap buffer in Readable stream; OpenAI expects a stream with a path.
     const stream = Readable.from(audioBuffer);
@@ -80,7 +97,7 @@ async function processWhisper(audioBuffer) {
     console.log('📝 Whisper transcribed:', transcript);
 
     if (transcript.toLowerCase().includes('remind me')) {
-      return scheduleReminder(transcript);
+      return scheduleFn(transcript, deps);
     }
 
     return null;

--- a/tests/mocks/factories.js
+++ b/tests/mocks/factories.js
@@ -1,0 +1,22 @@
+/**
+ * Centralized factories for constructing mocks of external services.
+ * Keeping them here avoids repetition across test suites.
+ */
+
+// Mock OpenAI client returning a predetermined transcript
+function mockOpenAI(transcript = '') {
+  return {
+    audio: {
+      transcriptions: {
+        create: async () => ({ text: transcript })
+      }
+    }
+  };
+}
+
+// Stub for ICS calendar event generation
+function mockCreateEvent(value = 'FAKE_ICS') {
+  return () => ({ error: null, value });
+}
+
+module.exports = { mockOpenAI, mockCreateEvent };


### PR DESCRIPTION
## Summary
- mock OpenAI and calendar client interactions during tests to keep runs offline
- add `SCHEDULER_TIME_MULTIPLIER` env for accelerated reminder scheduling
- document new config and testing strategy
- expose scheduler time multiplier via CLI or JSON config
- centralize mock factories for external services to streamline future tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f9dac72048325a92599af585ddb55